### PR TITLE
Fix: Adjust DPI Scaling and Visibility Issues for Screen Captures

### DIFF
--- a/SCapture/App.config
+++ b/SCapture/App.config
@@ -1,12 +1,12 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <configSections>
-        <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" >
-            <section name="SCapture.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
+        <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+            <section name="SCapture.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false"/>
         </sectionGroup>
     </configSections>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
     </startup>
     <userSettings>
         <SCapture.Properties.Settings>

--- a/SCapture/Classes/ScreenCapturer.cs
+++ b/SCapture/Classes/ScreenCapturer.cs
@@ -1,5 +1,6 @@
 ﻿using SCapture.Properties;
 using System;
+using System.Drawing;
 using System.IO;
 using System.Windows;
 using System.Windows.Interop;
@@ -67,9 +68,13 @@ namespace SCapture.Classes
         /// <returns>The image captured</returns>
         public static BitmapSource CaptureFullScreen()
         {
-            return CaptureRegion(0, 0,
-                (int)SystemParameters.PrimaryScreenWidth,
-                (int)SystemParameters.PrimaryScreenHeight);
+            var (scaleX, scaleY) = GetSystemDpiScale();
+
+            // Get the entire screen size with DPI scaling applied
+            int screenWidth = (int)(SystemParameters.PrimaryScreenWidth * scaleX);
+            int screenHeight = (int)(SystemParameters.PrimaryScreenHeight * scaleY);
+
+            return CaptureRegion(0, 0, screenWidth, screenHeight);
         }
 
         /// <summary>
@@ -141,6 +146,19 @@ namespace SCapture.Classes
             }
 
             return true;
+        }
+        /// <summary>
+        /// Get DPI Scale
+        /// </summary>
+        /// <returns></returns>
+        public static (double scaleX, double scaleY) GetSystemDpiScale()
+        {
+            using (Graphics graphics = Graphics.FromHwnd(IntPtr.Zero))
+            {
+                double dpiX = graphics.DpiX;
+                double dpiY = graphics.DpiY;
+                return (dpiX / 96.0, dpiY / 96.0); // 96.0 is the base DPI for 100% scaling
+            }
         }
     }
 }

--- a/SCapture/Properties/Resources.Designer.cs
+++ b/SCapture/Properties/Resources.Designer.cs
@@ -8,10 +8,10 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace SCapture.Properties
-{
-
-
+namespace SCapture.Properties {
+    using System;
+    
+    
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -19,51 +19,43 @@ namespace SCapture.Properties
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    internal class Resources
-    {
-
+    internal class Resources {
+        
         private static global::System.Resources.ResourceManager resourceMan;
-
+        
         private static global::System.Globalization.CultureInfo resourceCulture;
-
+        
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
-        internal Resources()
-        {
+        internal Resources() {
         }
-
+        
         /// <summary>
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Resources.ResourceManager ResourceManager
-        {
-            get
-            {
-                if ((resourceMan == null))
-                {
+        internal static global::System.Resources.ResourceManager ResourceManager {
+            get {
+                if (object.ReferenceEquals(resourceMan, null)) {
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("SCapture.Properties.Resources", typeof(Resources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
             }
         }
-
+        
         /// <summary>
         ///   Overrides the current thread's CurrentUICulture property for all
         ///   resource lookups using this strongly typed resource class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Globalization.CultureInfo Culture
-        {
-            get
-            {
+        internal static global::System.Globalization.CultureInfo Culture {
+            get {
                 return resourceCulture;
             }
-            set
-            {
+            set {
                 resourceCulture = value;
             }
         }

--- a/SCapture/Properties/Settings.Designer.cs
+++ b/SCapture/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace SCapture.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.1.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.9.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -32,7 +32,6 @@ namespace SCapture.Properties {
             }
             set {
                 this["AlwaysCopyToClipboard"] = value;
-                Settings.Default.Save();
             }
         }
         
@@ -45,7 +44,6 @@ namespace SCapture.Properties {
             }
             set {
                 this["AlwaysOpenToEditor"] = value;
-                Settings.Default.Save();
             }
         }
         
@@ -58,7 +56,6 @@ namespace SCapture.Properties {
             }
             set {
                 this["SaveFileFormat"] = value;
-                Settings.Default.Save();
             }
         }
     }

--- a/SCapture/SCapture.csproj
+++ b/SCapture/SCapture.csproj
@@ -8,11 +8,12 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>SCapture</RootNamespace>
     <AssemblyName>SCapture</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/SCapture/Windows/RegionCaptureWindow.xaml.cs
+++ b/SCapture/Windows/RegionCaptureWindow.xaml.cs
@@ -2,6 +2,7 @@
 using SCapture.Classes;
 using SCapture.Properties;
 using System;
+using System.Drawing;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -17,12 +18,12 @@ namespace SCapture.Windows
         /// <summary>
         /// The start position of the Region Rectangle
         /// </summary>
-        private Point Start;
+        private System.Windows.Point Start;
 
         /// <summary>
         /// The end position of the Region Rectangle
         /// </summary>
-        private Point Current;
+        private System.Windows.Point Current;
 
         /// <summary>
         /// Determines weather the user is drawing region or not
@@ -54,8 +55,17 @@ namespace SCapture.Windows
         {
             isDrawing = false;
 
-            // Calculate rectangle cords/size
-            BitmapSource bSource = ScreenCapturer.CaptureRegion((int)X, (int)Y, (int)W, (int)H);
+            // Get DPI scale
+            var (scaleX, scaleY) = GetSystemDpiScale();
+
+            // Apply the DPI scaling
+            int dpiAdjustedX = (int)(X * scaleX);
+            int dpiAdjustedY = (int)(Y * scaleY);
+            int dpiAdjustedW = (int)(W * scaleX);
+            int dpiAdjustedH = (int)(H * scaleY);
+
+            // Capture the region with DPI adjustment
+            BitmapSource bSource = ScreenCapturer.CaptureRegion(dpiAdjustedX, dpiAdjustedY, dpiAdjustedW, dpiAdjustedH);
 
             if (Settings.Default.AlwaysCopyToClipboard)
                 Clipboard.SetImage(bSource);
@@ -100,6 +110,17 @@ namespace SCapture.Windows
                 // Toogle visibility
                 if (Rect.Visibility != Visibility.Visible)
                     Rect.Visibility = Visibility.Visible;
+            }
+        }
+
+        //Method to get the DPI scale
+        private (double scaleX, double scaleY) GetSystemDpiScale()
+        {
+            using (Graphics graphics = Graphics.FromHwnd(IntPtr.Zero))
+            {
+                double dpiX = graphics.DpiX;
+                double dpiY = graphics.DpiY;
+                return (dpiX / 96.0, dpiY / 96.0); // 96 is the system DPI for 100% scaling
             }
         }
         #endregion

--- a/SCapture/Windows/RegionCaptureWindow.xaml.cs
+++ b/SCapture/Windows/RegionCaptureWindow.xaml.cs
@@ -64,12 +64,15 @@ namespace SCapture.Windows
             System.Windows.Point actualStart = this.PointToScreen(Start);
             System.Windows.Point actualCurrent = this.PointToScreen(Current);
 
-            int captureX = (int)actualStart.X;
-            int captureY = (int)actualStart.Y;
-            int captureW = (int)Math.Abs(actualCurrent.X - actualStart.X);
-            int captureH = (int)Math.Abs(actualCurrent.Y - actualStart.Y);
+            // Determine the top-left corner of the selection rectangle
+            int selectionX = (int)Math.Min(actualStart.X, actualCurrent.X);
+            int selectionY = (int)Math.Min(actualStart.Y, actualCurrent.Y);
 
-            BitmapSource bSource = ScreenCapturer.CaptureRegion(captureX, captureY, captureW, captureH);
+            // Determine the width and height of the selection rectangle
+            int selectionW = (int)Math.Abs(actualCurrent.X - actualStart.X);
+            int selectionH = (int)Math.Abs(actualCurrent.Y - actualStart.Y);
+
+            BitmapSource bSource = ScreenCapturer.CaptureRegion(selectionX, selectionY, selectionW, selectionH);
 
             if (Settings.Default.AlwaysCopyToClipboard)
                 Clipboard.SetImage(bSource);


### PR DESCRIPTION
This pull request addresses several issues encountered with screen capture functionality in the SCapture project. Here's a breakdown of the changes and their benefits:

### Fixes Implemented:
1. **DPI Scaling Adjustment**: Implemented DPI scaling adjustments for the full screen capture method. This ensures that screen captures are accurate on high-DPI displays, fixing previous issues where captures were not correctly scaled to the system's DPI settings.

2. **Selection Visibility**: Modified the region capture workflow to hide the selection rectangle. Also fixed the opacity which was not being set to normal after selecting a region. This resolves the issue where the selection rectangle was visible and that the screen is not darker because of the opacity.

3. **Capture Region Accuracy**: Refined the calculation of the capture region to ensure the selected area corresponds exactly to the user's intention, particularly addressing offsets that appeared in the captured images.

4. **Consistent Area Selection**: Ensure consistent selection area in region selections.